### PR TITLE
Support errors in object and array values

### DIFF
--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import {Form, Checkbox} from 'semantic-ui-react';
-import {Field} from 'formik';
+import {Field, getIn} from 'formik';
 import {InputRef} from './InputRef';
 import {getFieldError, setFieldValue} from './helpers';
 
@@ -43,7 +43,7 @@ class FormikCheckbox extends Component {
                 />
               </InputRef>
               {error && (
-                <span className="sui-error-message">{form.errors[name]}</span>
+                <span className="sui-error-message">{getIn(form.errors, name)}</span>
               )}
             </Form.Field>
           );

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import {Form, Dropdown} from 'semantic-ui-react';
-import {Field} from 'formik';
+import {Field, getIn} from 'formik';
 import {getFieldError, setFieldValue} from './helpers';
 
 class FormikDropdown extends Component {
@@ -43,7 +43,7 @@ class FormikDropdown extends Component {
                 }}
               />
               {error && (
-                <span className="sui-error-message">{form.errors[name]}</span>
+                <span className="sui-error-message">{getIn(form.errors, name)}</span>
               )}
             </Form.Field>
           );

--- a/src/Input.js
+++ b/src/Input.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import {Form, Input} from 'semantic-ui-react';
-import {Field} from 'formik';
+import {Field, getIn} from 'formik';
 import {InputRef} from './InputRef';
 import {getFieldError, setFieldValue} from './helpers';
 
@@ -48,7 +48,7 @@ class FormikInput extends Component {
               </InputRef>
 
               {error && (
-                <span className="sui-error-message">{form.errors[name]}</span>
+                <span className="sui-error-message">{getIn(form.errors, name)}</span>
               )}
             </Form.Field>
           );

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import {Form, Radio} from 'semantic-ui-react';
-import {Field} from 'formik';
+import {Field, getIn} from 'formik';
 import {InputRef} from './InputRef';
 import {getFieldError, setFieldValue} from './helpers';
 
@@ -45,7 +45,7 @@ class FormikCheckbox extends Component {
                 />
               </InputRef>
               {error && (
-                <span className="sui-error-message">{form.errors[name]}</span>
+                <span className="sui-error-message">{getIn(form.errors, name)}</span>
               )}
             </Form.Field>
           );

--- a/src/TextArea.js
+++ b/src/TextArea.js
@@ -1,6 +1,6 @@
 import React, {Component, Fragment} from 'react';
 import {Form, Ref, TextArea} from 'semantic-ui-react';
-import {Field} from 'formik';
+import {Field, getIn} from 'formik';
 
 import {NullRef} from './InputRef';
 import {getFieldError, setFieldValue} from './helpers';
@@ -47,7 +47,7 @@ class FormikTextArea extends Component {
                 />
               </RefWrapper>
               {error && (
-                <span className="sui-error-message">{form.errors[name]}</span>
+                <span className="sui-error-message">{getIn(form.errors, name)}</span>
               )}
             </Form.Field>
           );

--- a/src/__tests__/__snapshots__/form.js.snap
+++ b/src/__tests__/__snapshots__/form.js.snap
@@ -266,6 +266,46 @@ exports[`Form child as a function 1`] = `
 </div>
 `;
 
+exports[`Form errors in complex types 1`] = `
+<div>
+  <form
+    class="ui form"
+  >
+    <div
+      class="error field"
+    >
+      <label
+        for="field_input_values.0.name"
+      >
+        Name
+      </label>
+      <div
+        class="ui input"
+      >
+        <input
+          id="field_input_values.0.name"
+          name="values.0.name"
+          type="text"
+          value="test"
+        />
+      </div>
+      <span
+        class="sui-error-message"
+      >
+        Error
+      </span>
+    </div>
+    <button
+      type="submit"
+      class="ui primary button"
+      role="button"
+    >
+      Submit
+    </button>
+  </form>
+</div>
+`;
+
 exports[`Form ignore loading 1`] = `
 <div>
   <form

--- a/src/__tests__/form.js
+++ b/src/__tests__/form.js
@@ -108,6 +108,28 @@ describe('Form', () => {
     });
   });
 
+  it('errors in complex types', async () => {
+    const {getByText, container} = render(
+      <Form
+        initialValues={{values: [{ name: 'test' }]}}
+        validate={() => ({ values: [{ name: 'Error' }]})}
+        onSubmit={() => {}}
+        render={() => {
+          return (
+            <React.Fragment>
+              <FormikInput name="values.0.name" label="Name" />
+              <Button.Submit>Submit</Button.Submit>
+            </React.Fragment>
+          );
+        }}
+      />
+    );
+
+    await findAndClick(() => getByText('Submit'));
+
+    expect(container).toMatchSnapshot();
+  });
+
   describe('Schema', () => {
     it('Input', () => {
       const schema = {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,10 +1,13 @@
+import {getIn} from 'formik';
+
 export const getFieldError = (field, form) => {
   const {name} = field;
   const {serverValidation} = form.status || {};
+  const touched = getIn(form.touched, name);
   const checkTouched = serverValidation
-    ? !form.touched[name]
-    : form.touched[name];
-  return checkTouched && form.errors[name];
+    ? !touched
+    : touched;
+  return checkTouched && getIn(form.errors, name);
 };
 
 export const setFieldValue = (form, name, value, shouldValidate) => {


### PR DESCRIPTION
Support errors in object and array values by supporting names with paths like `variants.0.name`.