### PR TITLE
Support TypeScript 3.5

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+type OmitKeys<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 declare module "formik-semantic-ui" {
   import {FormikConfig, FormikValues} from "formik";
@@ -72,7 +72,7 @@ declare module "formik-semantic-ui" {
     inputProps?: FormInputProps;
   }
 
-  export class Form<Values = FormikValues> extends React.Component<Omit<FormikConfig<Values>, "component"> |
+  export class Form<Values = FormikValues> extends React.Component<OmitKeys<FormikConfig<Values>, "component"> |
     Pick<StrictFormProps, "className" | "inverted" | "size"> | {
     serverValidation?: boolean
     ignoreLoading?: boolean
@@ -99,7 +99,7 @@ declare module "formik-semantic-ui" {
   export class Dropdown extends React.Component<DropdownComponentProps> {
   }
 
-  class ButtonBase extends React.Component<Omit<FormButtonProps, "type">> {
+  class ButtonBase extends React.Component<OmitKeys<FormButtonProps, "type">> {
   }
 
   export class Button extends ButtonBase {


### PR DESCRIPTION
Add support for TypeScript 3.5 that now includes the Omit type.

See https://www.infoq.com/news/2019/06/typescript-3-5-release/